### PR TITLE
Add support to BOLT11 payment requests

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -70,6 +70,7 @@
 <script src="bower_components/angular-moment/angular-moment.js"></script>
 <script src="bower_components/clipboard/dist/clipboard.js"></script>
 <script src="bower_components/ngclipboard/dist/ngclipboard.js"></script>
+<script src="bower_components/js-sha256/src/sha256.js"></script>
 <!-- endbower -->
 <!-- endbuild -->
 
@@ -99,6 +100,7 @@
 <script src="scripts/directives/invoices_widget.js"></script>
 <script src="scripts/directives/amountunitconverter.js"></script>
 <script src="browserified/bolt11.browserified.js"></script> <!-- This contains the bolt11 directive -->
+<script src="scripts/directives/sha256_verify.js"></script>
 
 <script src="scripts/directives/nodeid_validation.js"></script>
 <script src="scripts/directives/route_validation.js"></script>

--- a/app/index.html
+++ b/app/index.html
@@ -98,6 +98,7 @@
 <script src="scripts/directives/send_pay_widget.js"></script>
 <script src="scripts/directives/invoices_widget.js"></script>
 <script src="scripts/directives/amountunitconverter.js"></script>
+<script src="browserified/bolt11.browserified.js"></script> <!-- This contains the bolt11 directive -->
 
 <script src="scripts/directives/nodeid_validation.js"></script>
 <script src="scripts/directives/route_validation.js"></script>

--- a/app/scripts/controllers/my_wallet_widget.js
+++ b/app/scripts/controllers/my_wallet_widget.js
@@ -52,7 +52,7 @@ angular.module('App')
                 LightningService.getFundsSum()
             ];
 
-            this.updateAddresses ();
+            _self.updateAddresses ();
 
             $q.all(promises)
                 .then(function (response) {

--- a/app/scripts/controllers/send_pay_widget.js
+++ b/app/scripts/controllers/send_pay_widget.js
@@ -79,14 +79,31 @@ angular.module('App')
         };
 
         this.submitBOLT11 = function () {
-            console.log(_self.bolt11);
-            _self.bolt11.payreq = null;
+            _self.loading = true;
 
-            _self.bolt11.disableSubmit = false;
-            $interval.cancel(_self.bolt11.interval);
+            LightningService.pay(
+                _self.bolt11.payreq.paymentRequest,
+                _self.bolt11.msatoshi,
+                _self.bolt11.description,
+                _self.bolt11.riskfactor,
+                _self.bolt11.maxfeepercent
+                )
+                .then(function () {
+                    _self.bolt11.payreq = null;
 
-            $scope.sendPayForm.$setPristine();
-            $scope.sendPayForm.$setUntouched();
+                    _self.bolt11.disableSubmit = false;
+                    $interval.cancel(_self.bolt11.interval);
+
+                    $scope.sendPayForm.$setPristine();
+                    $scope.sendPayForm.$setUntouched();
+                })
+                .catch(function (error) {
+                    console.warn(error);
+                    return $q.reject(error);
+                })
+                .finally(function () {
+                    _self.loading = false;
+                });
         };
 
         this.submit = function () {

--- a/app/scripts/controllers/send_pay_widget.js
+++ b/app/scripts/controllers/send_pay_widget.js
@@ -129,7 +129,7 @@ angular.module('App')
             _self.bolt11.timeLeft = newVal ? (newVal.expireTime || 0) : 0;
 
             if (newVal && newVal.expireTime) {
-                var timeLeft = Math.max(_self.bolt11.payreq.timestamp + _self.bolt11.payreq.expireTime - Date.now(), 0);
+                var timeLeft = _self.bolt11.timeLeft = Math.max(_self.bolt11.payreq.timestamp + _self.bolt11.payreq.expireTime - Math.floor(Date.now() / 1000), 0);
 
                 if (timeLeft > 0) {
                     _self.bolt11.interval = $interval(function () {

--- a/app/scripts/directives/bolt11.js
+++ b/app/scripts/directives/bolt11.js
@@ -13,7 +13,7 @@ angular.module('App')
     .directive('bolt11', function () {
         function link(scope, element, attrs, ngModel) {
             ngModel.$validators.bolt11 = function (value) {
-                return typeof value === 'object' && value !== null && value.complete;
+                return typeof value === 'object' && value !== null;
             };
 
             ngModel.$parsers.push(function (value) {
@@ -27,6 +27,24 @@ angular.module('App')
 
                 ngModel.$setViewValue(originalInputValue);
                 ngModel.$render();
+
+                if (result) {
+                    result.parsedDescription = null;
+                    result.fallbackAddress = null;
+
+                    var mapTags = {
+                        'description': 'parsedDescription',
+                        'fallback_address': 'fallbackAddress',
+                        'expire_time': 'expireTime'
+                    };
+
+                    // We could sort and bsearch but honestly I don't think it's worth for so few tags
+                    result.tags.forEach(function (tag) {
+                        if (Object.keys(mapTags).indexOf(tag.tagName) > -1) {
+                            result[mapTags[tag.tagName]] = tag.data;
+                        }
+                    });
+                }
 
                 return result;
             });

--- a/app/scripts/directives/bolt11.js
+++ b/app/scripts/directives/bolt11.js
@@ -1,0 +1,41 @@
+'use strict';
+
+/**
+ * @ngdoc directive
+ * @name App.directive:amountUnitConverter
+ * @description
+ * # amountUnitConverter
+ */
+
+var bolt11 = require('bolt11');
+
+angular.module('App')
+    .directive('bolt11', function () {
+        function link(scope, element, attrs, ngModel) {
+            ngModel.$validators.bolt11 = function (value) {
+                return typeof value === 'object' && value !== null && value.complete;
+            };
+
+            ngModel.$parsers.push(function (value) {
+                var result = null;
+                var originalInputValue = value;
+
+                try {
+                    result = bolt11.decode(value);
+                } catch (err) {
+                }
+
+                ngModel.$setViewValue(originalInputValue);
+                ngModel.$render();
+
+                return result;
+            });
+        }
+
+        return {
+            link: link,
+            restrict: 'A',
+            require: 'ngModel',
+            scope: {}
+        };
+    });

--- a/app/scripts/directives/bolt11.js
+++ b/app/scripts/directives/bolt11.js
@@ -35,7 +35,8 @@ angular.module('App')
                     var mapTags = {
                         'description': 'parsedDescription',
                         'fallback_address': 'fallbackAddress',
-                        'expire_time': 'expireTime'
+                        'expire_time': 'expireTime',
+                        'purpose_commit_hash': 'descriptionHash'
                     };
 
                     // We could sort and bsearch but honestly I don't think it's worth for so few tags

--- a/app/scripts/directives/sha256_verify.js
+++ b/app/scripts/directives/sha256_verify.js
@@ -1,0 +1,26 @@
+'use strict';
+
+/**
+ * @ngdoc function
+ * @name App.directive:sha256Verify
+ * @description
+ * # sha256Verify
+ * Directive of the App
+ */
+angular.module('App')
+    .directive('sha256Verify', function ($window) {
+        function link(scope, element, attrs, ngModel) {
+            ngModel.$validators.sha256Verify = function (value) {
+                return typeof value === 'string' && $window.sha256(value) === scope.sha256Verify;
+            };
+        }
+
+        return {
+            link: link,
+            restrict: 'A',
+            require: 'ngModel',
+            scope: {
+                sha256Verify: '<'
+            }
+        };
+    });

--- a/app/scripts/services/lightning.js
+++ b/app/scripts/services/lightning.js
@@ -134,4 +134,15 @@ angular.module('App')
             }).$promise
                 .then(ResourcesGeneratorService.successHandler, ResourcesGeneratorService.failureHandler);
         };
+
+        this.pay = function (payreq, msatoshi, description, riskfactor, maxfeepercent) {
+            return ResourcesGeneratorService.getResource('lightning/pay').post({
+                payreq: payreq,
+                msatoshi: msatoshi,
+                description: description,
+                riskfactor: riskfactor,
+                maxfeepercent: maxfeepercent
+            }).$promise
+                .then(ResourcesGeneratorService.successHandler, ResourcesGeneratorService.failureHandler);
+        };
     });

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -88,6 +88,10 @@ md-card-header button.md-button {
   margin-top: 4px;
 }
 
+.widget-line.bottom.big {
+    margin-bottom: 8px;
+}
+
 /* line 83, ../sass/main.scss */
 .half-size {
   transform: scale(0.5);

--- a/app/views/widgets/send_pay.html
+++ b/app/views/widgets/send_pay.html
@@ -8,82 +8,171 @@
             <span class="md-title">Pay an invoice</span>
             <span class="md-subhead">Send a payment to a Lightning node</span>
         </md-card-header-text>
+        <md-button class="md-icon-button" ng-click="ctrlSendPay.switchMode();">
+            <md-icon>switch_camera</md-icon>
+            <md-tooltip md-delay="600" md-direction="top">
+                Switch mode
+            </md-tooltip>
+        </md-button>
     </md-card-header>
 
     <md-card-content class="widget-content">
         <form name="sendPayForm">
-
-            <md-input-container class="md-block">
-                <label>RHash</label>
-                <input required name="rhash" ng-model="ctrlSendPay.payment.rhash" minlength="64" maxlength="64">
-                <div ng-messages="sendPayForm.rhash.$error">
-                    <div ng-message="required">This is required.</div>
-
-                    <div ng-message="minlength">Invalid RHash.</div>
-                    <div ng-message="maxlength">Invalid RHash.</div>
-                </div>
-            </md-input-container>
-
-            <div layout="row" layout-align="space-between center" ng-if="SettingsService.get('advancedMode')">
-                <md-input-container flex="80">
-                    <label>Route</label>
-                    <input ng-required="!ctrlSendPay.payment.autoRoute" ng-disabled="ctrlSendPay.payment.autoRoute"
-                           name="route" route-validation disable-route-validation="ctrlSendPay.payment.autoRoute"
-                           ng-model="ctrlSendPay.payment.route">
-                    <div ng-messages="sendPayForm.route.$error">
-                        <div ng-message="required">This is required.</div>
-                        <div ng-message="routeValidation">Invalid route.</div>
-                    </div>
-                </md-input-container>
-
-                <md-input-container flex="20">
-                    <md-checkbox class="md-primary" ng-model="ctrlSendPay.payment.autoRoute">
-                        Auto
-                        <md-tooltip md-delay="600" md-direction="top">
-                            Automatically calculate the route
-                        </md-tooltip>
-                    </md-checkbox>
-                </md-input-container>
-            </div>
-
-            <div ng-show="ctrlSendPay.payment.autoRoute">
+            <div ng-if="ctrlSendPay.mode === 'bolt11'">
                 <md-input-container class="md-block">
-                    <label>Node</label>
-                    <input ng-required="ctrlSendPay.payment.autoRoute" name="node"
-                           ng-model="ctrlSendPay.payment.nodeid" nodeid-validation>
-                    <div ng-messages="sendPayForm.node.$error">
+                    <label>BOLT11 Payment Request</label>
+                    <textarea required name="payreq" ng-model="ctrlSendPay.bolt11.payreq" bolt11></textarea>
+                    <div ng-messages="sendPayForm.payreq.$error">
                         <div ng-message="required">This is required.</div>
-                        <div ng-message="nodeidValidation">Invalid NodeID.</div>
+                        <div ng-message="bolt11">This is not a valid BOLT11 Payment Request.</div>
                     </div>
                 </md-input-container>
 
-                <div layout="row" layout-align="space-between center">
-                    <md-input-container class="md-block md-icon-right" flex="50">
-                        <label>Amount</label>
-                        <input type="number" ng-required="ctrlSendPay.payment.autoRoute" name="amount"
-                               ng-model="ctrlSendPay.payment.amount" amount-unit-converter="mSAT">
-                        <span class="input-unit-name">{{SettingsService.get('unit')}}</span>
-                        <div ng-messages="sendPayForm.amount.$error">
+                <md-input-container class="md-block"
+                                    ng-if="ctrlSendPay.bolt11.payreq !== null && ctrlSendPay.bolt11.payreq.satoshis === null">
+                    <label>Amount</label>
+                    <input required name="msatoshi" ng-model="ctrlSendPay.bolt11.msatoshi" amount-unit-converter="mSAT">
+                    <div ng-messages="sendPayForm.msatoshi.$error">
+                        <div ng-message="required">The amount is required.</div>
+                    </div>
+                </md-input-container>
+
+                <div layout="row" layout-align="space-between center" ng-if="SettingsService.get('advancedMode')">
+                    <md-input-container flex="50">
+                        <label>Risk factor</label>
+                        <input required name="riskfactor" ng-model="ctrlSendPay.bolt11.riskfactor">
+                        <div ng-messages="sendPayForm.riskfactor.$error">
                             <div ng-message="required">This is required.</div>
                         </div>
                     </md-input-container>
 
-
-                    <md-input-container class="md-block" flex="50">
-                        <label>Risk Factor</label>
-                        <input type="number" ng-required="ctrlSendPay.payment.autoRoute" name="riskFactor"
-                               ng-model="ctrlSendPay.payment.riskFactor" min="0">
-                        <div ng-messages="sendPayForm.riskFactor.$error">
+                    <md-input-container flex="50">
+                        <label>Max fee percent</label>
+                        <input required name="maxfeepercent" ng-model="ctrlSendPay.bolt11.maxfeepercent">
+                        <div ng-messages="sendPayForm.maxfeepercent.$error">
                             <div ng-message="required">This is required.</div>
-                            <div ng-message="min">The riskfactor cannot be negative.</div>
                         </div>
                     </md-input-container>
                 </div>
+
+                <md-input-container layout="column" layout-align="space-between stretch">
+                    <!-- Display the amount -->
+                    <div layout="column" layout-align="space-between stretch" class="widget-line bottom big"
+                         ng-if="ctrlSendPay.bolt11.payreq !== null && ctrlSendPay.bolt11.payreq.satoshis">
+
+                        <span flex="100" style="margin-bottom: 4px;">Amount:</span>
+                        <span flex="100"
+                              class="code">{{ctrlSendPay.bolt11.payreq.satoshis | AmountUnitFilter : 'SAT'}}</span>
+                    </div>
+
+                    <!-- Display the description -->
+                    <div layout="column" layout-align="space-between stretch" class="widget-line bottom big"
+                         ng-if="ctrlSendPay.bolt11.payreq !== null && ctrlSendPay.bolt11.payreq.parsedDescription">
+
+                        <span flex="100" style="margin-bottom: 4px;">Description:</span>
+                        <span flex="100" class="code">{{ctrlSendPay.bolt11.payreq.parsedDescription}}</span>
+                    </div>
+
+                    <!-- Display the fallback address -->
+                    <div layout="column" layout-align="space-between stretch" class="widget-line bottom big"
+                         ng-if="ctrlSendPay.bolt11.payreq !== null && ctrlSendPay.bolt11.payreq.fallbackAddress">
+
+                        <span flex="100" style="margin-bottom: 4px;">Fallback Address:</span>
+                        <span flex="100" class="code">{{ctrlSendPay.bolt11.payreq.fallbackAddress.address}}</span>
+                    </div>
+
+                    <!-- Display the expire time -->
+                    <div layout="column" layout-align="space-between stretch" class="widget-line bottom big"
+                         ng-if="ctrlSendPay.bolt11.payreq !== null && ctrlSendPay.bolt11.payreq.expireTime">
+
+                        <span flex="100" style="margin-bottom: 4px;">Time left:</span>
+                        <span flex="100" class="code" ng-if="ctrlSendPay.bolt11.timeLeft > 0">{{ctrlSendPay.bolt11.timeLeft}} s</span>
+                        <span flex="100" class="code" ng-if="ctrlSendPay.bolt11.timeLeft <= 0">-- EXPIRED --</span>
+                    </div>
+                </md-input-container>
             </div>
 
+            <!-- Advanced mode -->
+            <div ng-if="ctrlSendPay.mode === 'advanced'">
+                <md-input-container class="md-block">
+                    <label>RHash</label>
+                    <input required name="rhash" ng-model="ctrlSendPay.payment.rhash" minlength="64" maxlength="64">
+                    <div ng-messages="sendPayForm.rhash.$error">
+                        <div ng-message="required">This is required.</div>
+
+                        <div ng-message="minlength">Invalid RHash.</div>
+                        <div ng-message="maxlength">Invalid RHash.</div>
+                    </div>
+                </md-input-container>
+
+                <div layout="row" layout-align="space-between center" ng-if="SettingsService.get('advancedMode')">
+                    <md-input-container flex="80">
+                        <label>Route</label>
+                        <input ng-required="!ctrlSendPay.payment.autoRoute" ng-disabled="ctrlSendPay.payment.autoRoute"
+                               name="route" route-validation disable-route-validation="ctrlSendPay.payment.autoRoute"
+                               ng-model="ctrlSendPay.payment.route">
+                        <div ng-messages="sendPayForm.route.$error">
+                            <div ng-message="required">This is required.</div>
+                            <div ng-message="routeValidation">Invalid route.</div>
+                        </div>
+                    </md-input-container>
+
+                    <md-input-container flex="20">
+                        <md-checkbox class="md-primary" ng-model="ctrlSendPay.payment.autoRoute">
+                            Auto
+                            <md-tooltip md-delay="600" md-direction="top">
+                                Automatically calculate the route
+                            </md-tooltip>
+                        </md-checkbox>
+                    </md-input-container>
+                </div>
+
+                <div ng-show="ctrlSendPay.payment.autoRoute">
+                    <md-input-container class="md-block">
+                        <label>Node</label>
+                        <input ng-required="ctrlSendPay.payment.autoRoute" name="node"
+                               ng-model="ctrlSendPay.payment.nodeid" nodeid-validation>
+                        <div ng-messages="sendPayForm.node.$error">
+                            <div ng-message="required">This is required.</div>
+                            <div ng-message="nodeidValidation">Invalid NodeID.</div>
+                        </div>
+                    </md-input-container>
+
+                    <div layout="row" layout-align="space-between center">
+                        <md-input-container class="md-block md-icon-right" flex="50">
+                            <label>Amount</label>
+                            <input type="number" ng-required="ctrlSendPay.payment.autoRoute" name="amount"
+                                   ng-model="ctrlSendPay.payment.amount" amount-unit-converter="mSAT">
+                            <span class="input-unit-name">{{SettingsService.get('unit')}}</span>
+                            <div ng-messages="sendPayForm.amount.$error">
+                                <div ng-message="required">This is required.</div>
+                            </div>
+                        </md-input-container>
+
+
+                        <md-input-container class="md-block" flex="50">
+                            <label>Risk Factor</label>
+                            <input type="number" ng-required="ctrlSendPay.payment.autoRoute" name="riskFactor"
+                                   ng-model="ctrlSendPay.payment.riskFactor" min="0">
+                            <div ng-messages="sendPayForm.riskFactor.$error">
+                                <div ng-message="required">This is required.</div>
+                                <div ng-message="min">The riskfactor cannot be negative.</div>
+                            </div>
+                        </md-input-container>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Submit button - common part -->
             <div layout="row" layout-align="left center">
-                <md-button style="margin: 0;" class="md-raised md-primary" ng-disabled="sendPayForm.$invalid"
-                           ng-click="ctrlSendPay.submit()">Send payment
+                <md-button style="margin: 0; position: relative;" class="md-raised md-primary"
+                           ng-disabled="sendPayForm.$invalid || ctrlSendPay.bolt11.disableSubmit"
+                           ng-click="ctrlSendPay.submit()">
+                    Send payment
+                    <md-progress-linear style="position: absolute; left: 0; bottom: 0; transform: scaleY(1.6);"
+                                        md-mode="determinate" ng-if="ctrlSendPay.bolt11.timeLeft > 0"
+                                        ng-class="{'md-warn': ctrlSendPay.bolt11.timeLeft < 30}"
+                                        value="{{100 * ctrlSendPay.bolt11.timeLeft / ctrlSendPay.bolt11.payreq.expireTime}}"></md-progress-linear>
                 </md-button>
                 <md-progress-circular ng-if="ctrlSendPay.calculatingRoute" flex="98" class="half-size"
                                       style="margin-left: 15px;"></md-progress-circular>

--- a/app/views/widgets/send_pay.html
+++ b/app/views/widgets/send_pay.html
@@ -37,6 +37,16 @@
                     </div>
                 </md-input-container>
 
+                <md-input-container class="md-block"
+                                    ng-if="ctrlSendPay.bolt11.payreq !== null && ctrlSendPay.bolt11.payreq.descriptionHash">
+                    <label>Description</label>
+                    <textarea required name="description" ng-model="ctrlSendPay.bolt11.description" sha256-verify="ctrlSendPay.bolt11.payreq.descriptionHash"></textarea>
+                    <div ng-messages="sendPayForm.description.$error">
+                        <div ng-message="required">This is required.</div>
+                        <div ng-message="sha256Verify">Invalid description.</div>
+                    </div>
+                </md-input-container>
+
                 <div layout="row" layout-align="space-between center" ng-if="SettingsService.get('advancedMode')">
                     <md-input-container flex="50">
                         <label>Risk factor</label>

--- a/bower.json
+++ b/bower.json
@@ -1,22 +1,23 @@
 {
-    "name": "lightning-ui-webapp",
-    "version": "1.0.0",
-    "dependencies": {
-        "angular": "^1.4.0",
-        "angular-animate": "^1.4.0",
-        "angular-aria": "^1.4.0",
-        "angular-cookies": "^1.4.0",
-        "angular-messages": "^1.4.0",
-        "angular-resource": "^1.4.0",
-        "angular-route": "^1.4.0",
-        "angular-sanitize": "^1.4.0",
-        "angular-material": "^1.1.5",
-        "angular-moment": "^1.0.1",
-        "ngclipboard": "^1.1.1"
-    },
-    "devDependencies": {
-        "angular-mocks": "^1.4.0"
-    },
-    "appPath": "app",
-    "moduleName": "App"
+  "name": "lightning-ui-webapp",
+  "version": "1.0.0",
+  "dependencies": {
+    "angular": "^1.4.0",
+    "angular-animate": "^1.4.0",
+    "angular-aria": "^1.4.0",
+    "angular-cookies": "^1.4.0",
+    "angular-messages": "^1.4.0",
+    "angular-resource": "^1.4.0",
+    "angular-route": "^1.4.0",
+    "angular-sanitize": "^1.4.0",
+    "angular-material": "^1.1.5",
+    "angular-moment": "^1.0.1",
+    "ngclipboard": "^1.1.1",
+    "js-sha256": "^0.9.0"
+  },
+  "devDependencies": {
+    "angular-mocks": "^1.4.0"
+  },
+  "appPath": "app",
+  "moduleName": "App"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,6 +3,16 @@
     "requires": true,
     "lockfileVersion": 1,
     "dependencies": {
+        "JSONStream": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+            "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+            "dev": true,
+            "requires": {
+                "jsonparse": "1.3.1",
+                "through": "2.3.8"
+            }
+        },
         "abbrev": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
@@ -24,6 +34,24 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz",
             "integrity": "sha1-bpXwJTrRYf8BJ9symD5eLlNS1Zo=",
             "dev": true
+        },
+        "acorn-node": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.3.0.tgz",
+            "integrity": "sha512-efP54n3d1aLfjL2UMdaXa6DsswwzJeI5rqhbFvXMrKiJ6eJFpf+7R0zN7t8IC+XKn2YOAFAv6xbBNgHUkoHWLw==",
+            "dev": true,
+            "requires": {
+                "acorn": "5.5.3",
+                "xtend": "4.0.1"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "5.5.3",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+                    "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+                    "dev": true
+                }
+            }
         },
         "after": {
             "version": "0.8.2",
@@ -77,6 +105,23 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
             "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
             "dev": true
+        },
+        "ansidiff": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/ansidiff/-/ansidiff-1.0.0.tgz",
+            "integrity": "sha1-1KPtiasWcPIMCX3vdZ802URHiqs=",
+            "dev": true,
+            "requires": {
+                "diff": "1.0.8"
+            },
+            "dependencies": {
+                "diff": {
+                    "version": "1.0.8",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
+                    "integrity": "sha1-NDJ2MI7Jkbe8giZ+1VvBQR+XFmY=",
+                    "dev": true
+                }
+            }
         },
         "anymatch": {
             "version": "1.3.2",
@@ -196,11 +241,54 @@
             "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
             "dev": true
         },
+        "asn1.js": {
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+            "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.0"
+            }
+        },
+        "assert": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+            "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+            "dev": true,
+            "requires": {
+                "util": "0.10.3"
+            }
+        },
         "assert-plus": {
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
             "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
             "dev": true
+        },
+        "astquery": {
+            "version": "0.0.11",
+            "resolved": "https://registry.npmjs.org/astquery/-/astquery-0.0.11.tgz",
+            "integrity": "sha1-FTjFTT86eIw2KULvK6sTkDb+nN0=",
+            "dev": true
+        },
+        "astw": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz",
+            "integrity": "sha1-e9QXhNMkk5h66yOba04cV6hzuRc=",
+            "dev": true,
+            "requires": {
+                "acorn": "4.0.13"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "4.0.13",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+                    "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+                    "dev": true
+                }
+            }
         },
         "async": {
             "version": "0.1.22",
@@ -263,10 +351,24 @@
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
             "dev": true
         },
+        "base-x": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
+            "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
+            "requires": {
+                "safe-buffer": "5.1.1"
+            }
+        },
         "base64-arraybuffer": {
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
             "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
+            "dev": true
+        },
+        "base64-js": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
+            "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w==",
             "dev": true
         },
         "base64-url": {
@@ -309,6 +411,11 @@
                 "tweetnacl": "0.14.5"
             }
         },
+        "bech32": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.3.tgz",
+            "integrity": "sha512-yuVFUvrNcoJi0sv5phmqc6P+Fl1HjRDRNOOkHY2X/3LBy2bIGNSFx4fZ95HMaXHupuS7cZR15AsvtmCIF4UEyg=="
+        },
         "beeper": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
@@ -323,6 +430,11 @@
             "requires": {
                 "callsite": "1.0.0"
             }
+        },
+        "bigi": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/bigi/-/bigi-1.4.2.tgz",
+            "integrity": "sha1-nGZalfiLiwj8Bc/XMfVhhZ1yWCU="
         },
         "bin-build": {
             "version": "2.2.0",
@@ -402,6 +514,46 @@
             "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
             "dev": true
         },
+        "bindings": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+            "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+        },
+        "bip66": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+            "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+            "requires": {
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "bitcoin-ops": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz",
+            "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow=="
+        },
+        "bitcoinjs-lib": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-3.3.2.tgz",
+            "integrity": "sha512-l5qqvbaK8wwtANPf6oEffykycg4383XgEYdia1rI7/JpGf1jfRWlOUCvx5TiTZS7kyIvY4j/UhIQ2urLsvGkzw==",
+            "requires": {
+                "bech32": "1.1.3",
+                "bigi": "1.4.2",
+                "bip66": "1.1.5",
+                "bitcoin-ops": "1.4.1",
+                "bs58check": "2.1.1",
+                "create-hash": "1.1.3",
+                "create-hmac": "1.1.6",
+                "ecurve": "1.0.6",
+                "merkle-lib": "2.0.10",
+                "pushdata-bitcoin": "1.0.1",
+                "randombytes": "2.0.6",
+                "safe-buffer": "5.1.1",
+                "typeforce": "1.12.0",
+                "varuint-bitcoin": "1.1.0",
+                "wif": "2.0.6"
+            }
+        },
         "bl": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
@@ -455,6 +607,11 @@
             "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
             "dev": true
         },
+        "bn.js": {
+            "version": "4.11.8",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+            "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+        },
         "body-parser": {
             "version": "1.13.3",
             "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.3.tgz",
@@ -478,6 +635,24 @@
                     "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz",
                     "integrity": "sha1-LstC/SlHRJIiCaLnxATayHk9it4=",
                     "dev": true
+                }
+            }
+        },
+        "bolt11": {
+            "version": "git://github.com/bitcoinjs/bolt11.git#9d344c02652d7151b1eba7252c43e35428c1988f",
+            "requires": {
+                "bech32": "1.1.3",
+                "bitcoinjs-lib": "3.3.2",
+                "bn.js": "4.11.8",
+                "lodash": "4.17.5",
+                "safe-buffer": "5.1.1",
+                "secp256k1": "3.5.0"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.17.5",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+                    "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
                 }
             }
         },
@@ -679,6 +854,479 @@
                 "repeat-element": "1.1.2"
             }
         },
+        "brorand": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+            "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+        },
+        "browser-pack": {
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.4.tgz",
+            "integrity": "sha512-Q4Rvn7P6ObyWfc4stqLWHtG1MJ8vVtjgT24Zbu+8UTzxYuZouqZsmNRRTFVMY/Ux0eIKv1d+JWzsInTX+fdHPQ==",
+            "dev": true,
+            "requires": {
+                "JSONStream": "1.3.2",
+                "combine-source-map": "0.8.0",
+                "defined": "1.0.0",
+                "safe-buffer": "5.1.1",
+                "through2": "2.0.3",
+                "umd": "3.0.1"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.5",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+                    "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.0.3",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                    "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.1"
+                    }
+                },
+                "through2": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+                    "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "2.3.5",
+                        "xtend": "4.0.1"
+                    }
+                }
+            }
+        },
+        "browser-resolve": {
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+            "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+            "dev": true,
+            "requires": {
+                "resolve": "1.1.7"
+            },
+            "dependencies": {
+                "resolve": {
+                    "version": "1.1.7",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+                    "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+                    "dev": true
+                }
+            }
+        },
+        "browserify": {
+            "version": "14.5.0",
+            "resolved": "https://registry.npmjs.org/browserify/-/browserify-14.5.0.tgz",
+            "integrity": "sha512-gKfOsNQv/toWz+60nSPfYzuwSEdzvV2WdxrVPUbPD/qui44rAkB3t3muNtmmGYHqrG56FGwX9SUEQmzNLAeS7g==",
+            "dev": true,
+            "requires": {
+                "JSONStream": "1.3.2",
+                "assert": "1.4.1",
+                "browser-pack": "6.0.4",
+                "browser-resolve": "1.11.2",
+                "browserify-zlib": "0.2.0",
+                "buffer": "5.1.0",
+                "cached-path-relative": "1.0.1",
+                "concat-stream": "1.5.2",
+                "console-browserify": "1.1.0",
+                "constants-browserify": "1.0.0",
+                "crypto-browserify": "3.12.0",
+                "defined": "1.0.0",
+                "deps-sort": "2.0.0",
+                "domain-browser": "1.1.7",
+                "duplexer2": "0.1.4",
+                "events": "1.1.1",
+                "glob": "7.1.2",
+                "has": "1.0.1",
+                "htmlescape": "1.1.1",
+                "https-browserify": "1.0.0",
+                "inherits": "2.0.3",
+                "insert-module-globals": "7.0.2",
+                "labeled-stream-splicer": "2.0.0",
+                "module-deps": "4.1.1",
+                "os-browserify": "0.3.0",
+                "parents": "1.0.1",
+                "path-browserify": "0.0.0",
+                "process": "0.11.10",
+                "punycode": "1.4.1",
+                "querystring-es3": "0.2.1",
+                "read-only-stream": "2.0.0",
+                "readable-stream": "2.3.5",
+                "resolve": "1.5.0",
+                "shasum": "1.0.2",
+                "shell-quote": "1.6.1",
+                "stream-browserify": "2.0.1",
+                "stream-http": "2.8.0",
+                "string_decoder": "1.0.3",
+                "subarg": "1.0.0",
+                "syntax-error": "1.4.0",
+                "through2": "2.0.3",
+                "timers-browserify": "1.4.2",
+                "tty-browserify": "0.0.1",
+                "url": "0.11.0",
+                "util": "0.10.3",
+                "vm-browserify": "0.0.4",
+                "xtend": "4.0.1"
+            },
+            "dependencies": {
+                "browserify-zlib": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+                    "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+                    "dev": true,
+                    "requires": {
+                        "pako": "1.0.6"
+                    }
+                },
+                "concat-stream": {
+                    "version": "1.5.2",
+                    "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+                    "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.0.6",
+                        "typedarray": "0.0.6"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "2.0.6",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                            "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                            "dev": true,
+                            "requires": {
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.3",
+                                "isarray": "1.0.0",
+                                "process-nextick-args": "1.0.7",
+                                "string_decoder": "0.10.31",
+                                "util-deprecate": "1.0.2"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "0.10.31",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                            "dev": true
+                        }
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "1.1.8"
+                    }
+                },
+                "pako": {
+                    "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+                    "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.5",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+                    "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.0.3",
+                        "util-deprecate": "1.0.2"
+                    },
+                    "dependencies": {
+                        "process-nextick-args": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+                            "dev": true
+                        }
+                    }
+                },
+                "shell-quote": {
+                    "version": "1.6.1",
+                    "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+                    "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+                    "dev": true,
+                    "requires": {
+                        "array-filter": "0.0.1",
+                        "array-map": "0.0.0",
+                        "array-reduce": "0.0.0",
+                        "jsonify": "0.0.0"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                    "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.1"
+                    }
+                },
+                "through2": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+                    "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "2.3.5",
+                        "xtend": "4.0.1"
+                    }
+                }
+            }
+        },
+        "browserify-aes": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
+            "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
+            "requires": {
+                "buffer-xor": "1.0.3",
+                "cipher-base": "1.0.4",
+                "create-hash": "1.1.3",
+                "evp_bytestokey": "1.0.3",
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "browserify-cache-api": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/browserify-cache-api/-/browserify-cache-api-3.0.1.tgz",
+            "integrity": "sha1-liR+hT8Gj9bg1FzHPwuyzZd47wI=",
+            "dev": true,
+            "requires": {
+                "async": "1.5.2",
+                "through2": "2.0.3",
+                "xtend": "4.0.1"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "1.5.2",
+                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+                    "dev": true
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.5",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+                    "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.0.3",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                    "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.1"
+                    }
+                },
+                "through2": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+                    "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "2.3.5",
+                        "xtend": "4.0.1"
+                    }
+                }
+            }
+        },
+        "browserify-cipher": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+            "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
+            "dev": true,
+            "requires": {
+                "browserify-aes": "1.1.1",
+                "browserify-des": "1.0.0",
+                "evp_bytestokey": "1.0.3"
+            }
+        },
+        "browserify-des": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+            "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
+            "dev": true,
+            "requires": {
+                "cipher-base": "1.0.4",
+                "des.js": "1.0.0",
+                "inherits": "2.0.3"
+            }
+        },
+        "browserify-incremental": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/browserify-incremental/-/browserify-incremental-3.1.1.tgz",
+            "integrity": "sha1-BxPLdYckemMqnwjPG9FpuHi2Koo=",
+            "dev": true,
+            "requires": {
+                "JSONStream": "0.10.0",
+                "browserify-cache-api": "3.0.1",
+                "through2": "2.0.3",
+                "xtend": "4.0.1"
+            },
+            "dependencies": {
+                "JSONStream": {
+                    "version": "0.10.0",
+                    "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
+                    "integrity": "sha1-dDSdDYlSK3HzDwoD/5vSDKbxKsA=",
+                    "dev": true,
+                    "requires": {
+                        "jsonparse": "0.0.5",
+                        "through": "2.3.8"
+                    }
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "jsonparse": {
+                    "version": "0.0.5",
+                    "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+                    "integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ=",
+                    "dev": true
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.5",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+                    "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.0.3",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                    "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.1"
+                    }
+                },
+                "through2": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+                    "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "2.3.5",
+                        "xtend": "4.0.1"
+                    }
+                }
+            }
+        },
+        "browserify-rsa": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+            "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "randombytes": "2.0.6"
+            }
+        },
+        "browserify-sign": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+            "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "browserify-rsa": "4.0.1",
+                "create-hash": "1.1.3",
+                "create-hmac": "1.1.6",
+                "elliptic": "6.4.0",
+                "inherits": "2.0.3",
+                "parse-asn1": "5.1.0"
+            }
+        },
         "browserify-zlib": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
@@ -695,6 +1343,33 @@
             "dev": true,
             "requires": {
                 "caniuse-db": "1.0.30000733"
+            }
+        },
+        "bs58": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+            "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+            "requires": {
+                "base-x": "3.0.4"
+            }
+        },
+        "bs58check": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.1.tgz",
+            "integrity": "sha512-okRQiWc5FJuA2VOwQ1hB7Sf0MyEFg/EwRN12h4b8HrJoGkZ3xq1CGjkaAfYloLcZyqixQnO5mhPpN6IcHSplVg==",
+            "requires": {
+                "bs58": "4.0.1",
+                "create-hash": "1.1.3"
+            }
+        },
+        "buffer": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
+            "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
+            "dev": true,
+            "requires": {
+                "base64-js": "1.2.3",
+                "ieee754": "1.1.8"
             }
         },
         "buffer-crc32": {
@@ -747,6 +1422,11 @@
                 }
             }
         },
+        "buffer-xor": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+            "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+        },
         "buffers": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
@@ -759,10 +1439,22 @@
             "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
             "dev": true
         },
+        "builtin-status-codes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+            "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+            "dev": true
+        },
         "bytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz",
             "integrity": "sha1-rJPEEOL/ycx89LRks4KJBn9eR7Q=",
+            "dev": true
+        },
+        "cached-path-relative": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
+            "integrity": "sha1-0JxLUoAKpMB44t2BqGmqyQ0uVOc=",
             "dev": true
         },
         "callsite": {
@@ -963,6 +1655,15 @@
                 }
             }
         },
+        "cipher-base": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+            "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+            "requires": {
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.1"
+            }
+        },
         "clap": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
@@ -1151,6 +1852,32 @@
                     "version": "4.17.4",
                     "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
                     "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+                    "dev": true
+                }
+            }
+        },
+        "combine-source-map": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
+            "integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
+            "dev": true,
+            "requires": {
+                "convert-source-map": "1.1.3",
+                "inline-source-map": "0.6.2",
+                "lodash.memoize": "3.0.4",
+                "source-map": "0.5.7"
+            },
+            "dependencies": {
+                "convert-source-map": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+                    "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
                     "dev": true
                 }
             }
@@ -1411,6 +2138,12 @@
                 "upper-case": "1.1.3"
             }
         },
+        "constants-browserify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+            "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+            "dev": true
+        },
         "content-type": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
@@ -1463,6 +2196,16 @@
             "integrity": "sha1-+mIuG8OIvyVzCQgta2UgDOZwkLo=",
             "dev": true
         },
+        "create-ecdh": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+            "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "elliptic": "6.4.0"
+            }
+        },
         "create-error-class": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
@@ -1472,6 +2215,30 @@
                 "capture-stack-trace": "1.0.0"
             }
         },
+        "create-hash": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+            "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
+            "requires": {
+                "cipher-base": "1.0.4",
+                "inherits": "2.0.3",
+                "ripemd160": "2.0.1",
+                "sha.js": "2.4.10"
+            }
+        },
+        "create-hmac": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+            "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
+            "requires": {
+                "cipher-base": "1.0.4",
+                "create-hash": "1.1.3",
+                "inherits": "2.0.3",
+                "ripemd160": "2.0.1",
+                "safe-buffer": "5.1.1",
+                "sha.js": "2.4.10"
+            }
+        },
         "cryptiles": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
@@ -1479,6 +2246,25 @@
             "dev": true,
             "requires": {
                 "boom": "0.4.2"
+            }
+        },
+        "crypto-browserify": {
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+            "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+            "dev": true,
+            "requires": {
+                "browserify-cipher": "1.0.0",
+                "browserify-sign": "4.0.4",
+                "create-ecdh": "4.0.0",
+                "create-hash": "1.1.3",
+                "create-hmac": "1.1.6",
+                "diffie-hellman": "5.0.2",
+                "inherits": "2.0.3",
+                "pbkdf2": "3.0.14",
+                "public-encrypt": "4.0.0",
+                "randombytes": "2.0.6",
+                "randomfill": "1.0.4"
             }
         },
         "csrf": {
@@ -1861,6 +2647,12 @@
             "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
             "dev": true
         },
+        "defined": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+            "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+            "dev": true
+        },
         "delayed-stream": {
             "version": "0.0.5",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
@@ -1873,11 +2665,99 @@
             "integrity": "sha1-gK7GTJ1tl+ZcwqnKqTwKpqv3Oqo=",
             "dev": true
         },
+        "deps-sort": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
+            "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
+            "dev": true,
+            "requires": {
+                "JSONStream": "1.3.2",
+                "shasum": "1.0.2",
+                "subarg": "1.0.0",
+                "through2": "2.0.3"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.5",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+                    "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.0.3",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                    "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.1"
+                    }
+                },
+                "through2": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+                    "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "2.3.5",
+                        "xtend": "4.0.1"
+                    }
+                }
+            }
+        },
+        "des.js": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+            "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.0"
+            }
+        },
         "destroy": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
             "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
             "dev": true
+        },
+        "detective": {
+            "version": "4.7.1",
+            "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
+            "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
+            "dev": true,
+            "requires": {
+                "acorn": "5.5.3",
+                "defined": "1.0.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "5.5.3",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+                    "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+                    "dev": true
+                }
+            }
         },
         "di": {
             "version": "0.0.1",
@@ -1890,6 +2770,17 @@
             "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
             "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
             "dev": true
+        },
+        "diffie-hellman": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+            "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "miller-rabin": "4.0.1",
+                "randombytes": "2.0.6"
+            }
         },
         "dom-serialize": {
             "version": "2.2.1",
@@ -1926,6 +2817,12 @@
                     "dev": true
                 }
             }
+        },
+        "domain-browser": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+            "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
+            "dev": true
         },
         "domelementtype": {
             "version": "1.3.0",
@@ -2014,6 +2911,16 @@
                         "safe-buffer": "5.1.1"
                     }
                 }
+            }
+        },
+        "drbg.js": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+            "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+            "requires": {
+                "browserify-aes": "1.1.1",
+                "create-hash": "1.1.3",
+                "create-hmac": "1.1.6"
             }
         },
         "duplexer2": {
@@ -2121,11 +3028,34 @@
                 "jsbn": "0.1.1"
             }
         },
+        "ecurve": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/ecurve/-/ecurve-1.0.6.tgz",
+            "integrity": "sha512-/BzEjNfiSuB7jIWKcS/z8FK9jNjmEWvUV2YZ4RLSmcDtP7Lq0m6FvDuSnJpBlDpGRpfRQeTLGLBI8H+kEv0r+w==",
+            "requires": {
+                "bigi": "1.4.2",
+                "safe-buffer": "5.1.1"
+            }
+        },
         "ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
             "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
             "dev": true
+        },
+        "elliptic": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+            "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+            "requires": {
+                "bn.js": "4.11.8",
+                "brorand": "1.1.0",
+                "hash.js": "1.1.3",
+                "hmac-drbg": "1.0.1",
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.0",
+                "minimalistic-crypto-utils": "1.0.1"
+            }
         },
         "encodeurl": {
             "version": "1.0.1",
@@ -2311,6 +3241,12 @@
                 "es6-symbol": "3.1.1"
             }
         },
+        "es5-shim": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.0.6.tgz",
+            "integrity": "sha1-RDvx8FA83qvOsB7ICoSvG48cqfc=",
+            "dev": true
+        },
         "es6-iterator": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
@@ -2339,6 +3275,12 @@
             "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw=",
             "dev": true
         },
+        "es6-shim": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.35.3.tgz",
+            "integrity": "sha1-m/tzY/7//4emzbbNk+QF7DxLbyY=",
+            "dev": true
+        },
         "es6-symbol": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
@@ -2358,6 +3300,25 @@
                         "es5-ext": "0.10.30"
                     }
                 }
+            }
+        },
+        "es6-transpiler": {
+            "version": "0.7.18",
+            "resolved": "https://registry.npmjs.org/es6-transpiler/-/es6-transpiler-0.7.18.tgz",
+            "integrity": "sha1-3lIJVE0bssKCyu0Ky3/bpzHtZV8=",
+            "dev": true,
+            "requires": {
+                "ansidiff": "1.0.0",
+                "astquery": "0.0.11",
+                "es5-shim": "4.0.6",
+                "es6-shim": "0.35.3",
+                "jsesc": "2.5.1",
+                "regenerate": "1.3.3",
+                "simple-fmt": "0.1.0",
+                "simple-is": "0.2.0",
+                "string-alter": "0.7.3",
+                "stringmap": "0.2.2",
+                "stringset": "0.2.1"
             }
         },
         "es6-weak-map": {
@@ -2463,6 +3424,21 @@
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
             "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=",
             "dev": true
+        },
+        "events": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+            "dev": true
+        },
+        "evp_bytestokey": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+            "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+            "requires": {
+                "md5.js": "1.3.4",
+                "safe-buffer": "5.1.1"
+            }
         },
         "exec-buffer": {
             "version": "2.0.1",
@@ -3942,6 +4918,12 @@
                 }
             }
         },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
+        },
         "gaze": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
@@ -4429,6 +5411,61 @@
                 "html-minifier": "0.6.9"
             }
         },
+        "grunt-browserify": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/grunt-browserify/-/grunt-browserify-5.2.0.tgz",
+            "integrity": "sha512-q2KKJiXiwgew6+iR3GN44Pbee7jpCxdDnIDnkShQw7fCHWEoSWHnOc4jm4lgoCaHFjVXK3O1di3WHsMF3W6BGw==",
+            "dev": true,
+            "requires": {
+                "async": "2.6.0",
+                "browserify": "14.5.0",
+                "browserify-incremental": "3.1.1",
+                "glob": "7.1.2",
+                "lodash": "4.17.5",
+                "resolve": "1.5.0",
+                "watchify": "3.11.0"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "2.6.0",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+                    "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+                    "dev": true,
+                    "requires": {
+                        "lodash": "4.17.5"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.5",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+                    "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+                    "dev": true
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "1.1.8"
+                    }
+                }
+            }
+        },
         "grunt-concurrent": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/grunt-concurrent/-/grunt-concurrent-1.0.1.tgz",
@@ -4829,6 +5866,69 @@
                     "version": "2.4.2",
                     "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
                     "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+                    "dev": true
+                }
+            }
+        },
+        "grunt-es6-transpiler": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/grunt-es6-transpiler/-/grunt-es6-transpiler-1.0.2.tgz",
+            "integrity": "sha1-FZ2I/n9/naumPRV7NJllae+BekQ=",
+            "dev": true,
+            "requires": {
+                "chalk": "1.1.3",
+                "each-async": "1.1.1",
+                "es6-transpiler": "0.7.18",
+                "mkdirp": "0.5.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    }
+                },
+                "has-ansi": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                    "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
                     "dev": true
                 }
             }
@@ -5665,6 +6765,15 @@
                 "har-schema": "2.0.0"
             }
         },
+        "has": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+            "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+            "dev": true,
+            "requires": {
+                "function-bind": "1.1.1"
+            }
+        },
         "has-ansi": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
@@ -5698,6 +6807,23 @@
                 "sparkles": "1.0.0"
             }
         },
+        "hash-base": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+            "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
+            "requires": {
+                "inherits": "2.0.3"
+            }
+        },
+        "hash.js": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+            "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+            "requires": {
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.0"
+            }
+        },
         "hasha": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
@@ -5718,6 +6844,16 @@
                 "cryptiles": "0.2.2",
                 "hoek": "0.9.1",
                 "sntp": "0.2.4"
+            }
+        },
+        "hmac-drbg": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+            "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+            "requires": {
+                "hash.js": "1.1.3",
+                "minimalistic-assert": "1.0.0",
+                "minimalistic-crypto-utils": "1.0.1"
             }
         },
         "hoek": {
@@ -5750,6 +6886,12 @@
                 "relateurl": "0.2.7",
                 "uglify-js": "2.4.24"
             }
+        },
+        "htmlescape": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+            "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
+            "dev": true
         },
         "htmlparser2": {
             "version": "3.8.3",
@@ -5795,6 +6937,12 @@
                 "ctype": "0.5.3"
             }
         },
+        "https-browserify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+            "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+            "dev": true
+        },
         "i": {
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/i/-/i-0.3.5.tgz",
@@ -5805,6 +6953,12 @@
             "version": "0.2.11",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
             "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
+            "dev": true
+        },
+        "ieee754": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+            "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
             "dev": true
         },
         "imagemin": {
@@ -6026,14 +7180,30 @@
         "inherits": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-            "dev": true
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
             "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
             "dev": true
+        },
+        "inline-source-map": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz",
+            "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
+            "dev": true,
+            "requires": {
+                "source-map": "0.5.7"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
+            }
         },
         "inquirer": {
             "version": "0.7.1",
@@ -6056,6 +7226,121 @@
                     "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
                     "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
                     "dev": true
+                }
+            }
+        },
+        "insert-module-globals": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.2.tgz",
+            "integrity": "sha512-p3s7g96Nm62MbHRuj9ZXab0DuJNWD7qcmdUXCOQ/ZZn42DtDXfsLill7bq19lDCx3K3StypqUnuE3H2VmIJFUw==",
+            "dev": true,
+            "requires": {
+                "JSONStream": "1.3.2",
+                "combine-source-map": "0.7.2",
+                "concat-stream": "1.5.2",
+                "is-buffer": "1.1.5",
+                "lexical-scope": "1.2.0",
+                "process": "0.11.10",
+                "through2": "2.0.3",
+                "xtend": "4.0.1"
+            },
+            "dependencies": {
+                "combine-source-map": {
+                    "version": "0.7.2",
+                    "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
+                    "integrity": "sha1-CHAxKFazB6h8xKxIbzqaYq7MwJ4=",
+                    "dev": true,
+                    "requires": {
+                        "convert-source-map": "1.1.3",
+                        "inline-source-map": "0.6.2",
+                        "lodash.memoize": "3.0.4",
+                        "source-map": "0.5.7"
+                    }
+                },
+                "concat-stream": {
+                    "version": "1.5.2",
+                    "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+                    "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.0.6",
+                        "typedarray": "0.0.6"
+                    }
+                },
+                "convert-source-map": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+                    "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
+                    "dev": true
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.0.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                    "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "0.10.31",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                },
+                "through2": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+                    "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "2.3.5",
+                        "xtend": "4.0.1"
+                    },
+                    "dependencies": {
+                        "process-nextick-args": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+                            "dev": true
+                        },
+                        "readable-stream": {
+                            "version": "2.3.5",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+                            "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+                            "dev": true,
+                            "requires": {
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.3",
+                                "isarray": "1.0.0",
+                                "process-nextick-args": "2.0.0",
+                                "safe-buffer": "5.1.1",
+                                "string_decoder": "1.0.3",
+                                "util-deprecate": "1.0.2"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.0.3",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                            "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                            "dev": true,
+                            "requires": {
+                                "safe-buffer": "5.1.1"
+                            }
+                        }
+                    }
                 }
             }
         },
@@ -6578,6 +7863,12 @@
                 }
             }
         },
+        "jsesc": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+            "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+            "dev": true
+        },
         "jshint": {
             "version": "2.8.0",
             "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.8.0.tgz",
@@ -6744,6 +8035,12 @@
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
             "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+            "dev": true
+        },
+        "jsonparse": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+            "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
             "dev": true
         },
         "jsprim": {
@@ -7051,6 +8348,17 @@
                 }
             }
         },
+        "labeled-stream-splicer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz",
+            "integrity": "sha1-pS4dE4AkwAuGscDJH2d5GLiuClk=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "isarray": "0.0.1",
+                "stream-splicer": "2.0.0"
+            }
+        },
         "latest-version": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-0.2.0.tgz",
@@ -7106,6 +8414,15 @@
                         "safe-buffer": "5.1.1"
                     }
                 }
+            }
+        },
+        "lexical-scope": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
+            "integrity": "sha1-/Ope3HBKSzqHls3KQZw6CvryLfQ=",
+            "dev": true,
+            "requires": {
+                "astw": "2.2.0"
             }
         },
         "load-json-file": {
@@ -7307,6 +8624,12 @@
                 "lodash.isarguments": "3.1.0",
                 "lodash.isarray": "3.0.4"
             }
+        },
+        "lodash.memoize": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+            "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
+            "dev": true
         },
         "lodash.now": {
             "version": "2.4.1",
@@ -7586,6 +8909,26 @@
                 }
             }
         },
+        "md5.js": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+            "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+            "requires": {
+                "hash-base": "3.0.4",
+                "inherits": "2.0.3"
+            },
+            "dependencies": {
+                "hash-base": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+                    "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+                    "requires": {
+                        "inherits": "2.0.3",
+                        "safe-buffer": "5.1.1"
+                    }
+                }
+            }
+        },
         "media-typer": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -7666,6 +9009,11 @@
                 }
             }
         },
+        "merkle-lib": {
+            "version": "2.0.10",
+            "resolved": "https://registry.npmjs.org/merkle-lib/-/merkle-lib-2.0.10.tgz",
+            "integrity": "sha1-grjbrnXieneFOItz+ddyXQ9vMyY="
+        },
         "method-override": {
             "version": "2.3.9",
             "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.3.9.tgz",
@@ -7745,6 +9093,16 @@
                 }
             }
         },
+        "miller-rabin": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+            "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "brorand": "1.1.0"
+            }
+        },
         "mime": {
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
@@ -7765,6 +9123,16 @@
             "requires": {
                 "mime-db": "1.30.0"
             }
+        },
+        "minimalistic-assert": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+            "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
+        },
+        "minimalistic-crypto-utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+            "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
         },
         "minimatch": {
             "version": "0.2.14",
@@ -7804,6 +9172,106 @@
             "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
             "integrity": "sha1-dVSm+Nhxg0zJe1RisSLEwSTW3pE=",
             "dev": true
+        },
+        "module-deps": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",
+            "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
+            "dev": true,
+            "requires": {
+                "JSONStream": "1.3.2",
+                "browser-resolve": "1.11.2",
+                "cached-path-relative": "1.0.1",
+                "concat-stream": "1.5.2",
+                "defined": "1.0.0",
+                "detective": "4.7.1",
+                "duplexer2": "0.1.4",
+                "inherits": "2.0.3",
+                "parents": "1.0.1",
+                "readable-stream": "2.3.5",
+                "resolve": "1.5.0",
+                "stream-combiner2": "1.1.1",
+                "subarg": "1.0.0",
+                "through2": "2.0.3",
+                "xtend": "4.0.1"
+            },
+            "dependencies": {
+                "concat-stream": {
+                    "version": "1.5.2",
+                    "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+                    "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.0.6",
+                        "typedarray": "0.0.6"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "2.0.6",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                            "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                            "dev": true,
+                            "requires": {
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.3",
+                                "isarray": "1.0.0",
+                                "process-nextick-args": "1.0.7",
+                                "string_decoder": "0.10.31",
+                                "util-deprecate": "1.0.2"
+                            }
+                        }
+                    }
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.5",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+                    "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.0.3",
+                        "util-deprecate": "1.0.2"
+                    },
+                    "dependencies": {
+                        "process-nextick-args": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+                            "dev": true
+                        },
+                        "string_decoder": {
+                            "version": "1.0.3",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                            "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                            "dev": true,
+                            "requires": {
+                                "safe-buffer": "5.1.1"
+                            }
+                        }
+                    }
+                },
+                "through2": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+                    "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "2.3.5",
+                        "xtend": "4.0.1"
+                    }
+                }
+            }
         },
         "morgan": {
             "version": "1.6.1",
@@ -7869,9 +9337,7 @@
         "nan": {
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-            "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
-            "dev": true,
-            "optional": true
+            "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
         },
         "natives": {
             "version": "1.1.0",
@@ -8208,6 +9674,12 @@
                 }
             }
         },
+        "os-browserify": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+            "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
+            "dev": true
+        },
         "os-filter-obj": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/os-filter-obj/-/os-filter-obj-1.0.3.tgz",
@@ -8244,6 +9716,15 @@
             "dev": true,
             "requires": {
                 "minimist": "1.2.0"
+            }
+        },
+        "outpipe": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
+            "integrity": "sha1-UM+GFjZeh+Ax4ppeyTOaPaRyX6I=",
+            "dev": true,
+            "requires": {
+                "shell-quote": "1.4.3"
             }
         },
         "p-throttler": {
@@ -8312,6 +9793,28 @@
             "dev": true,
             "requires": {
                 "sentence-case": "1.1.3"
+            }
+        },
+        "parents": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+            "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
+            "dev": true,
+            "requires": {
+                "path-platform": "0.11.15"
+            }
+        },
+        "parse-asn1": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+            "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
+            "dev": true,
+            "requires": {
+                "asn1.js": "4.10.1",
+                "browserify-aes": "1.1.1",
+                "create-hash": "1.1.3",
+                "evp_bytestokey": "1.0.3",
+                "pbkdf2": "3.0.14"
             }
         },
         "parse-glob": {
@@ -8401,6 +9904,12 @@
                 "upper-case-first": "1.1.2"
             }
         },
+        "path-browserify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+            "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
+            "dev": true
+        },
         "path-case": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.2.tgz",
@@ -8429,6 +9938,18 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+            "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+            "dev": true
+        },
+        "path-platform": {
+            "version": "0.11.15",
+            "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+            "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
             "dev": true
         },
         "path-type": {
@@ -8461,6 +9982,19 @@
             "resolved": "https://registry.npmjs.org/pause/-/pause-0.1.0.tgz",
             "integrity": "sha1-68ikqGGf8LioGsFRPDQ0/0af23Q=",
             "dev": true
+        },
+        "pbkdf2": {
+            "version": "3.0.14",
+            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
+            "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
+            "dev": true,
+            "requires": {
+                "create-hash": "1.1.3",
+                "create-hmac": "1.1.6",
+                "ripemd160": "2.0.1",
+                "safe-buffer": "5.1.1",
+                "sha.js": "2.4.10"
+            }
         },
         "pend": {
             "version": "1.2.0",
@@ -8800,6 +10334,12 @@
                 "plur": "1.0.0"
             }
         },
+        "process": {
+            "version": "0.11.10",
+            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+            "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+            "dev": true
+        },
         "process-nextick-args": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
@@ -8846,6 +10386,19 @@
             "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
             "dev": true
         },
+        "public-encrypt": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+            "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "browserify-rsa": "4.0.1",
+                "create-hash": "1.1.3",
+                "parse-asn1": "5.1.0",
+                "randombytes": "2.0.6"
+            }
+        },
         "pump": {
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/pump/-/pump-0.3.5.tgz",
@@ -8890,6 +10443,14 @@
             "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
             "dev": true
         },
+        "pushdata-bitcoin": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
+            "integrity": "sha1-FZMdPNlnreUiBvUjqnMxrvfUOvc=",
+            "requires": {
+                "bitcoin-ops": "1.4.1"
+            }
+        },
         "q": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
@@ -8906,6 +10467,18 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
             "integrity": "sha1-wx2bdOwn33XlQ6hseHKO2NRiNgc=",
+            "dev": true
+        },
+        "querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+            "dev": true
+        },
+        "querystring-es3": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+            "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
             "dev": true
         },
         "random-bytes": {
@@ -8953,6 +10526,24 @@
                         "is-buffer": "1.1.5"
                     }
                 }
+            }
+        },
+        "randombytes": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+            "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+            "requires": {
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "randomfill": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+            "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+            "dev": true,
+            "requires": {
+                "randombytes": "2.0.6",
+                "safe-buffer": "5.1.1"
             }
         },
         "range-parser": {
@@ -9033,6 +10624,53 @@
                         "inherits": "2.0.3",
                         "isarray": "1.0.0",
                         "process-nextick-args": "1.0.7",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.0.3",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                    "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.1"
+                    }
+                }
+            }
+        },
+        "read-only-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
+            "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.5"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.5",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+                    "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
                         "safe-buffer": "5.1.1",
                         "string_decoder": "1.0.3",
                         "util-deprecate": "1.0.2"
@@ -9186,6 +10824,12 @@
             "requires": {
                 "esprima": "1.0.4"
             }
+        },
+        "regenerate": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+            "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+            "dev": true
         },
         "regex-cache": {
             "version": "0.4.4",
@@ -9371,6 +11015,15 @@
             "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
             "dev": true
         },
+        "resolve": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+            "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+            "dev": true,
+            "requires": {
+                "path-parse": "1.0.5"
+            }
+        },
         "response-time": {
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.2.tgz",
@@ -9407,6 +11060,15 @@
             "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
             "dev": true
         },
+        "ripemd160": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+            "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
+            "requires": {
+                "hash-base": "2.0.2",
+                "inherits": "2.0.3"
+            }
+        },
         "rndm": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
@@ -9422,8 +11084,7 @@
         "safe-buffer": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-            "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-            "dev": true
+            "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         },
         "sax": {
             "version": "1.2.4",
@@ -9431,6 +11092,21 @@
             "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
             "dev": true,
             "optional": true
+        },
+        "secp256k1": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
+            "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
+            "requires": {
+                "bindings": "1.3.0",
+                "bip66": "1.1.5",
+                "bn.js": "4.11.8",
+                "create-hash": "1.1.3",
+                "drbg.js": "1.0.1",
+                "elliptic": "6.4.0",
+                "nan": "2.7.0",
+                "safe-buffer": "5.1.1"
+            }
         },
         "seek-bzip": {
             "version": "1.0.5",
@@ -9598,6 +11274,36 @@
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
             "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
             "dev": true
+        },
+        "sha.js": {
+            "version": "2.4.10",
+            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.10.tgz",
+            "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
+            "requires": {
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "shasum": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+            "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
+            "dev": true,
+            "requires": {
+                "json-stable-stringify": "0.0.1",
+                "sha.js": "2.4.10"
+            },
+            "dependencies": {
+                "json-stable-stringify": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+                    "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
+                    "dev": true,
+                    "requires": {
+                        "jsonify": "0.0.0"
+                    }
+                }
+            }
         },
         "shell-quote": {
             "version": "1.4.3",
@@ -9942,6 +11648,54 @@
             "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
             "dev": true
         },
+        "stream-browserify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+            "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.5"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.5",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+                    "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.0.3",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                    "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.1"
+                    }
+                }
+            }
+        },
         "stream-combiner2": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
@@ -9993,10 +11747,115 @@
                 "readable-stream": "1.1.14"
             }
         },
+        "stream-http": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.0.tgz",
+            "integrity": "sha512-sZOFxI/5xw058XIRHl4dU3dZ+TTOIGJR78Dvo0oEAejIt4ou27k+3ne1zYmCV+v7UucbxIFQuOgnkTVHh8YPnw==",
+            "dev": true,
+            "requires": {
+                "builtin-status-codes": "3.0.0",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.5",
+                "to-arraybuffer": "1.0.1",
+                "xtend": "4.0.1"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.5",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+                    "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.0.3",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                    "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.1"
+                    }
+                }
+            }
+        },
         "stream-shift": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
             "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+            "dev": true
+        },
+        "stream-splicer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz",
+            "integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.5"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.5",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+                    "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.0.3",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                    "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.1"
+                    }
+                }
+            }
+        },
+        "string-alter": {
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/string-alter/-/string-alter-0.7.3.tgz",
+            "integrity": "sha1-qZ8gPXKTOWNItJ/HI916sKC42JI=",
             "dev": true
         },
         "string-length": {
@@ -10172,6 +12031,15 @@
                 "escape-string-regexp": "1.0.5"
             }
         },
+        "subarg": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+            "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
+            "dev": true,
+            "requires": {
+                "minimist": "1.2.0"
+            }
+        },
         "sum-up": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.3.tgz",
@@ -10299,6 +12167,15 @@
             "requires": {
                 "lower-case": "1.1.4",
                 "upper-case": "1.1.3"
+            }
+        },
+        "syntax-error": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
+            "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
+            "dev": true,
+            "requires": {
+                "acorn-node": "1.3.0"
             }
         },
         "tar-fs": {
@@ -10581,6 +12458,15 @@
             "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc=",
             "dev": true
         },
+        "timers-browserify": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+            "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
+            "dev": true,
+            "requires": {
+                "process": "0.11.10"
+            }
+        },
         "timers-ext": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.2.tgz",
@@ -10659,6 +12545,12 @@
             "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
             "dev": true
         },
+        "to-arraybuffer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+            "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+            "dev": true
+        },
         "touch": {
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.2.tgz",
@@ -10710,6 +12602,12 @@
             "integrity": "sha1-fcSjOvcVgatDN9qR2FylQn69mpc=",
             "dev": true
         },
+        "tty-browserify": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+            "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+            "dev": true
+        },
         "tunnel-agent": {
             "version": "0.4.3",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
@@ -10738,6 +12636,11 @@
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
             "dev": true
+        },
+        "typeforce": {
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.12.0.tgz",
+            "integrity": "sha512-fvnkvueAOFLhtAqDgIA/wMP21SMwS/NQESFKZuwVrj5m/Ew6eK2S0z0iB++cwtROPWDOhaT6OUfla8UwMw4Adg=="
         },
         "uglify-js": {
             "version": "2.4.24",
@@ -10793,6 +12696,12 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
             "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=",
+            "dev": true
+        },
+        "umd": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
+            "integrity": "sha1-iuVW4RAR9jwllnCKiDclnwGz1g4=",
             "dev": true
         },
         "underscore": {
@@ -10863,6 +12772,24 @@
             "integrity": "sha1-gD6wHy/rF5J9zOD2GH5yt19T9VQ=",
             "dev": true
         },
+        "url": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+            "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+            "dev": true,
+            "requires": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.3.2",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                    "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+                    "dev": true
+                }
+            }
+        },
         "url-parse-lax": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
@@ -10902,6 +12829,23 @@
                     "version": "2.2.4",
                     "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
                     "integrity": "sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0=",
+                    "dev": true
+                }
+            }
+        },
+        "util": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+            "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.1"
+            },
+            "dependencies": {
+                "inherits": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                    "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
                     "dev": true
                 }
             }
@@ -10960,6 +12904,14 @@
             "requires": {
                 "spdx-correct": "1.0.2",
                 "spdx-expression-parse": "1.0.4"
+            }
+        },
+        "varuint-bitcoin": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.0.tgz",
+            "integrity": "sha512-jCEPG+COU/1Rp84neKTyDJQr478/hAfVp5xxYn09QEH0yBjbmPeMfuuQIrp+BUD83hybtYZKhr5elV3bvdV1bA==",
+            "requires": {
+                "safe-buffer": "5.1.1"
             }
         },
         "vary": {
@@ -11119,6 +13071,15 @@
                 }
             }
         },
+        "vm-browserify": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+            "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+            "dev": true,
+            "requires": {
+                "indexof": "0.0.1"
+            }
+        },
         "void-elements": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
@@ -11186,6 +13147,221 @@
                 "wrap-fn": "0.1.5"
             }
         },
+        "watchify": {
+            "version": "3.11.0",
+            "resolved": "https://registry.npmjs.org/watchify/-/watchify-3.11.0.tgz",
+            "integrity": "sha512-7jWG0c3cKKm2hKScnSAMUEUjRJKXUShwMPk0ASVhICycQhwND3IMAdhJYmc1mxxKzBUJTSF5HZizfrKrS6BzkA==",
+            "dev": true,
+            "requires": {
+                "anymatch": "1.3.2",
+                "browserify": "16.1.1",
+                "chokidar": "1.7.0",
+                "defined": "1.0.0",
+                "outpipe": "1.1.1",
+                "through2": "2.0.3",
+                "xtend": "4.0.1"
+            },
+            "dependencies": {
+                "browserify": {
+                    "version": "16.1.1",
+                    "resolved": "https://registry.npmjs.org/browserify/-/browserify-16.1.1.tgz",
+                    "integrity": "sha512-iSH21jK0+IApV8YHOfmGt1qsGd74oflQ1Ko/28JOkWLFNBngAQfKb6WYIJ9CufH8vycqKX1sYU3y7ZrVhwevAg==",
+                    "dev": true,
+                    "requires": {
+                        "JSONStream": "1.3.2",
+                        "assert": "1.4.1",
+                        "browser-pack": "6.0.4",
+                        "browser-resolve": "1.11.2",
+                        "browserify-zlib": "0.2.0",
+                        "buffer": "5.1.0",
+                        "cached-path-relative": "1.0.1",
+                        "concat-stream": "1.6.0",
+                        "console-browserify": "1.1.0",
+                        "constants-browserify": "1.0.0",
+                        "crypto-browserify": "3.12.0",
+                        "defined": "1.0.0",
+                        "deps-sort": "2.0.0",
+                        "domain-browser": "1.2.0",
+                        "duplexer2": "0.1.4",
+                        "events": "2.0.0",
+                        "glob": "7.1.2",
+                        "has": "1.0.1",
+                        "htmlescape": "1.1.1",
+                        "https-browserify": "1.0.0",
+                        "inherits": "2.0.3",
+                        "insert-module-globals": "7.0.2",
+                        "labeled-stream-splicer": "2.0.0",
+                        "mkdirp": "0.5.1",
+                        "module-deps": "6.0.0",
+                        "os-browserify": "0.3.0",
+                        "parents": "1.0.1",
+                        "path-browserify": "0.0.0",
+                        "process": "0.11.10",
+                        "punycode": "1.4.1",
+                        "querystring-es3": "0.2.1",
+                        "read-only-stream": "2.0.0",
+                        "readable-stream": "2.3.5",
+                        "resolve": "1.5.0",
+                        "shasum": "1.0.2",
+                        "shell-quote": "1.6.1",
+                        "stream-browserify": "2.0.1",
+                        "stream-http": "2.8.0",
+                        "string_decoder": "1.0.3",
+                        "subarg": "1.0.0",
+                        "syntax-error": "1.4.0",
+                        "through2": "2.0.3",
+                        "timers-browserify": "1.4.2",
+                        "tty-browserify": "0.0.1",
+                        "url": "0.11.0",
+                        "util": "0.10.3",
+                        "vm-browserify": "0.0.4",
+                        "xtend": "4.0.1"
+                    }
+                },
+                "browserify-zlib": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+                    "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+                    "dev": true,
+                    "requires": {
+                        "pako": "1.0.6"
+                    }
+                },
+                "detective": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/detective/-/detective-5.1.0.tgz",
+                    "integrity": "sha512-TFHMqfOvxlgrfVzTEkNBSh9SvSNX/HfF4OFI2QFGCyPm02EsyILqnUeb5P6q7JZ3SFNTBL5t2sePRgrN4epUWQ==",
+                    "dev": true,
+                    "requires": {
+                        "acorn-node": "1.3.0",
+                        "defined": "1.0.0",
+                        "minimist": "1.2.0"
+                    }
+                },
+                "domain-browser": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+                    "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+                    "dev": true
+                },
+                "events": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/events/-/events-2.0.0.tgz",
+                    "integrity": "sha512-r/M5YkNg9zwI8QbSf7tsDWWJvO3PGwZXyG7GpFAxtMASnHL2eblFd7iHiGPtyGKKFPZ59S63NeX10Ws6WqGDcg==",
+                    "dev": true
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "1.1.8"
+                    }
+                },
+                "module-deps": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.0.0.tgz",
+                    "integrity": "sha512-BKsMhJJENEM4dTgqq2MDTTHXRHcNUFegoAwlG4HO4VMdUyMcJDKgfgI+MOv6tR5Iv8G3MKZFgsSiyP3ZoosRMw==",
+                    "dev": true,
+                    "requires": {
+                        "JSONStream": "1.3.2",
+                        "browser-resolve": "1.11.2",
+                        "cached-path-relative": "1.0.1",
+                        "concat-stream": "1.6.0",
+                        "defined": "1.0.0",
+                        "detective": "5.1.0",
+                        "duplexer2": "0.1.4",
+                        "inherits": "2.0.3",
+                        "parents": "1.0.1",
+                        "readable-stream": "2.3.5",
+                        "resolve": "1.5.0",
+                        "stream-combiner2": "1.1.1",
+                        "subarg": "1.0.0",
+                        "through2": "2.0.3",
+                        "xtend": "4.0.1"
+                    }
+                },
+                "pako": {
+                    "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+                    "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
+                    "dev": true
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.5",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+                    "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.0.3",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "shell-quote": {
+                    "version": "1.6.1",
+                    "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+                    "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+                    "dev": true,
+                    "requires": {
+                        "array-filter": "0.0.1",
+                        "array-map": "0.0.0",
+                        "array-reduce": "0.0.0",
+                        "jsonify": "0.0.0"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                    "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.1"
+                    }
+                },
+                "through2": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+                    "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "2.3.5",
+                        "xtend": "4.0.1"
+                    }
+                }
+            }
+        },
         "whet.extend": {
             "version": "0.9.9",
             "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
@@ -11197,6 +13373,14 @@
             "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
             "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
             "dev": true
+        },
+        "wif": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
+            "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
+            "requires": {
+                "bs58check": "2.1.1"
+            }
         },
         "win-release": {
             "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "autoprefixer-core": "^5.2.1",
         "grunt": "^0.4.5",
         "grunt-angular-templates": "^0.5.7",
+        "grunt-browserify": "^5.2.0",
         "grunt-concurrent": "^1.0.0",
         "grunt-contrib-clean": "^0.6.0",
         "grunt-contrib-compass": "^1.0.0",
@@ -18,6 +19,7 @@
         "grunt-contrib-jshint": "^0.11.0",
         "grunt-contrib-uglify": "^0.7.0",
         "grunt-contrib-watch": "^0.6.1",
+        "grunt-es6-transpiler": "^1.0.2",
         "grunt-filerev": "^2.1.2",
         "grunt-google-cdn": "^0.4.3",
         "grunt-jscs": "^1.8.0",
@@ -41,5 +43,8 @@
     },
     "scripts": {
         "test": "karma start test/karma.conf.js"
+    },
+    "dependencies": {
+        "bolt11": "git://github.com/bitcoinjs/bolt11.git#wip"
     }
 }

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -33,6 +33,7 @@ module.exports = function (config) {
             'bower_components/angular-moment/angular-moment.js',
             'bower_components/clipboard/dist/clipboard.js',
             'bower_components/ngclipboard/dist/ngclipboard.js',
+            'bower_components/js-sha256/src/sha256.js',
             'bower_components/angular-mocks/angular-mocks.js',
             // endbower
             'app/scripts/**/*.js',


### PR DESCRIPTION
This PR adds support to BOLT11 payment requests, as specified in the [RFC](https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md).

This is kind of a major update, because many things had to change in order to add all the required stuff: first of all, a [bolt11 parser](https://github.com/bitcoinjs/bolt11) has been added as npm module with browserify. Now, during `grunt serve` and builds the new `bolt11` directive is bundled with the module and then transpiled to ES5. This adds some seconds to live-reloading and build time.

Another bower module (`js-sha256`) has also been added: this is needed to add support to `SHA256`, which allows to verify the hashed payment description (when included in the payment request).

This update is paired with https://github.com/BHBNETWORK/lightning-ui-backend/commit/c71436f8ffd063bbf5fa09bf3d17073277405025